### PR TITLE
Parse out any prefixes in refs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,14 +26,20 @@ outputs:
 runs:
   using: 'composite'
   steps:
+  
+    # ${REF##*/} removes any prefixes
     - name: Check if tag is reachable from the default branch
       id: check-tag
       shell: bash
+      env:
+        GITHUB_TAG: ${{ steps.remove-prefix.outputs.result }}
+        GITHUB_DEFAULT_BRANCH: ${{ inputs.default-branch }}
+        GITHUB_REF: ${{ inputs.ref }}
       run: |
         errorIfNotReachable=${{ inputs.error-if-not-reachable }}
-        tag=${{ inputs.tag }}
-        defaultBranch=${{ inputs.default-branch }}
-        ref=${{ inputs.ref }}
+        tag=${GITHUB_TAG##*/}
+        defaultBranch=${GITHUB_DEFAULT_BRANCH##*/}
+        ref=${GITHUB_REF##*/}
 
         echo "Checking tag: $tag"
         echo "ErrorIfNotReachable: $errorIfNotReachable"


### PR DESCRIPTION
# Summary of PR changes

There are instances when the prefix is included on the inputs.  Parse out the prefix.

## PR Requirements
- [ ] For JavaScript actions, the action has been recompiled.  
  - See the *Recompiling* section of the repository's README.md for more details.
  - This does not apply to Composite Run Steps actions unless a package.json is present and contains a build script.
- [ ] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [ ] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
