### PR TITLE
ARCH-1615 - Update syntax for setting outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Check if tag is reachable by main
-        uses: im-open/is-tag-reachable-from-default-branch@v1.0.2
+        uses: im-open/is-tag-reachable-from-default-branch@v1.1.0
         with:
           tag: 'latest'
 
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Check if tag is reachable by main
-        uses: im-open/is-tag-reachable-from-default-branch@v1.0.2
+        uses: im-open/is-tag-reachable-from-default-branch@v1.1.0
         with:
           tag: 'latest'
           ref: ${{ github.ref }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Check if tag is reachable by master
         id: tag-check
-        uses: im-open/is-tag-reachable-from-default-branch@v1.0.2
+        uses: im-open/is-tag-reachable-from-default-branch@v1.1.0
         with:
           tag: 'latest'                 # The tag to check
           error-if-not-reachable: false # Don't throw an error if the tag is not reachable

--- a/action.yml
+++ b/action.yml
@@ -60,10 +60,10 @@ runs:
         if printf '%s\n' "${mergedTags[@]}" | grep -q -w $tag ; 
         then
           echo "The tag appears in the list of reachable tags"
-          echo "::set-output name=reachable::true"
+          echo "reachable=true" >> $GITHUB_OUTPUT
         else
           echo "::error::The tag does not appear to be reachable by from $defaultBranch."
-          echo "::set-output name=reachable::false"
+          echo "reachable=false" >> $GITHUB_OUTPUT
           if [ "$errorIfNotReachable" == "true" ]; then
             exit 1
           fi


### PR DESCRIPTION
# Summary of PR changes

-  Update syntax for setting outputs to comply with the [GitHub's new recommendations](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands) to avoid logging untrusted data.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
