### PR TITLE
Sort tags by version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
 
       - name: Check if tag is reachable by main
         # You may also reference just the major or major.minor version
-        uses: im-open/is-tag-reachable-from-default-branch@v1.1.1
+        uses: im-open/is-tag-reachable-from-default-branch@v1.1.2
         with:
           tag: 'latest'
 
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Check if tag is reachable by main
-        uses: im-open/is-tag-reachable-from-default-branch@v1.1.1
+        uses: im-open/is-tag-reachable-from-default-branch@v1.1.2
         with:
           tag: 'latest'
           ref: ${{ github.ref }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Check if tag is reachable by master
         id: tag-check
-        uses: im-open/is-tag-reachable-from-default-branch@v1.1.1
+        uses: im-open/is-tag-reachable-from-default-branch@v1.1.2
         with:
           tag: 'latest'                 # The tag to check
           error-if-not-reachable: false # Don't throw an error if the tag is not reachable

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,9 @@ runs:
           echo "::endgroup::"
         fi
 
-        mergedTags=$(git tag --merged)
+        # Store the list of tags reachable from the default branch (--merged)
+        # and sort them by ascending version number, interpreting the tag name as a version number (--sort="version:refname")
+        mergedTags=$(git tag --list --sort="version:refname" --merged)
 
         echo "Checking tag: $tag"
         echo "::group::The repository contains the following tags which are reachable from $defaultBranch"


### PR DESCRIPTION
# Summary of PR changes

## Cause of problem
This action sometimes fails with "line 28: printf: write error: Broken pipe"

Which is apparently caused because `grep` finds the tag it's looking for and terminates successfully before `printf` has finished writing its content into the pipe, so `printf` errors.

This is likely to happen when the list of tags is larger than the pipe's buffer and when the tag being searched is not at the end of the list.

Because tags are sorted lexicographically, a tag like v4.0.149 is listed ahead of tags v4.0.2–v.4.0.99

## Poor and partial solution in this PR

Modify the `git tag --merged` command to output the list of tags in order by the version number in the tag name. This way recent tags that are likely to be searched will be found at the end of the list so grep will be less likely to exit early.

## Better complete solution

Use grep to read from a file instead of reading input through a pipe from another command. See this [StackOverflow question](https://stackoverflow.com/questions/49664991/why-am-i-getting-cat-write-error-broken-pipe-rarely-and-not-always) for more discussion.

## PR Requirements
- [X] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [X] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
