### PR TITLE
Updating not reachable message

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
 
       - name: Check if tag is reachable by main
         # You may also reference just the major or major.minor version
-        uses: im-open/is-tag-reachable-from-default-branch@v1.1.3
+        uses: im-open/is-tag-reachable-from-default-branch@v1.1.4
         with:
           tag: 'latest'
 
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Check if tag is reachable by main
-        uses: im-open/is-tag-reachable-from-default-branch@v1.1.3
+        uses: im-open/is-tag-reachable-from-default-branch@v1.1.4
         with:
           tag: 'latest'
           ref: ${{ github.ref }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Check if tag is reachable by master
         id: tag-check
-        uses: im-open/is-tag-reachable-from-default-branch@v1.1.3
+        uses: im-open/is-tag-reachable-from-default-branch@v1.1.4
         with:
           tag: 'latest'                 # The tag to check
           error-if-not-reachable: false # Don't throw an error if the tag is not reachable

--- a/action.yml
+++ b/action.yml
@@ -63,9 +63,11 @@ runs:
           echo "The tag appears in the list of reachable tags"
           echo "reachable=true" >> $GITHUB_OUTPUT
         else
-          echo "::error::The tag does not appear to be reachable by from $defaultBranch."
           echo "reachable=false" >> $GITHUB_OUTPUT
           if [ "$errorIfNotReachable" == "true" ]; then
+            echo "::error::The tag does not appear to be reachable from $defaultBranch."
             exit 1
+          else
+            echo "::warning::The tag does not appear to be reachable from $defaultBranch."    
           fi
         fi


### PR DESCRIPTION
Only use an error command if the `error-if-not-reachable` input is set, otherwise just use a warning to indicate the tag is not reachable from the default branch

# Summary of PR changes



## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
